### PR TITLE
fix: remove BaseReward plugin to prevent double-counting base reward

### DIFF
--- a/src/multi_agent_package/scripts/run_from_config.py
+++ b/src/multi_agent_package/scripts/run_from_config.py
@@ -140,8 +140,9 @@ def build_environment(configs: dict) -> GridWorldEnv:
     # -----------------------------
     reward_fns = []
 
-    if reward_cfg["rewards"]["base"]["enabled"]:
-        reward_fns.append(get_reward_function("base"))
+    # base_reward() is called internally by gridworld.step() — do NOT add it
+    # here or every capture/death signal gets counted twice.
+    _ = reward_cfg["rewards"]["base"]["enabled"]  # validate key exists
 
     for r in reward_cfg["rewards"].get("shaping", []):
         reward_fns.append(


### PR DESCRIPTION
## Problem
`gridworld.step()` calls `base_reward()` internally on every step (gridworld.py:285).
`run_from_config.build_environment()` was also adding `BaseReward` into the
`reward_fn` plugin chain, which calls `base_reward()` a second time.

Result: every capture/death event was counting twice (+200/-200 instead of +100/-100),
inflating all reward signals and distorting training.

## Fix
Removed the `get_reward_function("base")` call from the plugin chain in
`run_from_config.py`. The base reward is handled entirely by the environment
internally. The `shaping` plugins (e.g. predator_distance) are unaffected.

## Tests
260/260 passing.
