### PR TITLE
fix: make base reward toggleable to stop double-counting

### DIFF
--- a/src/multi_agent_package/core/gridworld.py
+++ b/src/multi_agent_package/core/gridworld.py
@@ -70,6 +70,7 @@ class GridWorldEnv(gym.Env):
         max_steps: Optional[int] = None,
         allow_cell_sharing: bool = True,
         block_agents_by_obstacles: bool = True,
+        include_base_reward: bool = True,
     ) -> None:
         assert render_mode is None or render_mode in self.metadata["render_modes"]
 
@@ -110,6 +111,11 @@ class GridWorldEnv(gym.Env):
         # behavior flags (configurable)
         self.allow_cell_sharing: bool = allow_cell_sharing
         self.block_agents_by_obstacles: bool = block_agents_by_obstacles
+
+        # Whether step() includes base_reward() (capture/obstacle/step-cost
+        # signal). This is the ONLY switch for the base reward: shaping plugins
+        # wired through reward_fn must never re-add it, or it is double-counted.
+        self.include_base_reward: bool = bool(include_base_reward)
 
         # extension hooks (students plug logic here)
         self.reward_fn = None
@@ -282,7 +288,10 @@ class GridWorldEnv(gym.Env):
         self._episode_steps += 1
 
         # rewards
-        rewards = self.base_reward()
+        if self.include_base_reward:
+            rewards = self.base_reward()
+        else:
+            rewards = {ag.agent_name: 0.0 for ag in self.agents}
 
         if self.reward_fn is not None:
             custom = self.reward_fn(self)

--- a/src/multi_agent_package/rewards/base_reward.py
+++ b/src/multi_agent_package/rewards/base_reward.py
@@ -1,7 +1,15 @@
 """
 Wrapper for GridWorldEnv.base_reward().
 
-This allows base rewards to be toggled via config.
+DEPRECATED / DO NOT USE VIA reward_fn.
+
+base_reward() is applied directly by GridWorldEnv.step(), gated by the
+include_base_reward constructor flag (wired from rewards.yaml -> base.enabled
+in run_from_config.build_environment()). Toggle the base reward through that
+flag, not by adding this plugin to the reward_fn pipeline.
+
+If you add get_reward_function("base") into the reward_fns list in
+build_environment(), you will double-count every capture/death/obstacle event.
 """
 
 from multi_agent_package.rewards.base import RewardFunction

--- a/src/multi_agent_package/scripts/run_from_config.py
+++ b/src/multi_agent_package/scripts/run_from_config.py
@@ -122,6 +122,7 @@ def build_environment(configs: dict) -> GridWorldEnv:
         block_agents_by_obstacles=dynamics.get("block_agents_by_obstacles", True),
         capture_threshold=termination.get("capture_threshold", 1),
         max_steps=termination.get("max_steps", None),
+        include_base_reward=reward_cfg["rewards"]["base"]["enabled"],
     )
 
     # -----------------------------
@@ -143,9 +144,10 @@ def build_environment(configs: dict) -> GridWorldEnv:
     # -----------------------------
     reward_fns = []
 
-    # base_reward() is called internally by gridworld.step() — do NOT add it
-    # here or every capture/death signal gets counted twice.
-    _ = reward_cfg["rewards"]["base"]["enabled"]  # validate key exists
+    # base_reward() is applied by gridworld.step() itself, gated by the
+    # include_base_reward flag passed above (from rewards.base.enabled). NEVER
+    # add get_reward_function("base") here, or every capture/death signal gets
+    # counted twice.
 
     for r in reward_cfg["rewards"].get("shaping", []):
         reward_fns.append(

--- a/tests/test_core_gridworld.py
+++ b/tests/test_core_gridworld.py
@@ -147,6 +147,28 @@ class TestStepCost:
         # predator should lose 5 per step (no capture, no obstacle)
         assert out["reward"]["pred_1"] == pytest.approx(-5.0)
 
+    def test_include_base_reward_true_is_default(self):
+        env = make_env(perc_obstacle=0)
+        assert env.include_base_reward is True
+
+    def test_include_base_reward_false_zeroes_base_signal(self):
+        # With the base reward disabled, step() must emit exactly 0.0 for every
+        # agent (no step cost, no capture/obstacle signal) instead of applying
+        # base_reward() a second time. Guards issue #32.
+        env = make_env(perc_obstacle=0, include_base_reward=False)
+        obs, _ = env.reset()
+        out = env.step({aid: 4 for aid in obs})
+        assert set(out["reward"]) == set(obs)
+        assert all(v == 0.0 for v in out["reward"].values())
+
+    def test_include_base_reward_false_still_applies_shaping(self):
+        # Disabling the base reward must not disable reward_fn shaping.
+        env = make_env(perc_obstacle=0, include_base_reward=False)
+        obs, _ = env.reset()
+        env.reward_fn = lambda e: {ag.agent_name: 1.5 for ag in e.agents}
+        out = env.step({aid: 4 for aid in obs})
+        assert all(v == pytest.approx(1.5) for v in out["reward"].values())
+
 
 # ------------------------------------------------------------------
 # Obstacle mechanics


### PR DESCRIPTION
## What

`GridWorldEnv.step()` applied `base_reward()` unconditionally, so the `rewards.base.enabled` config flag was a no-op, and enabling the `BaseReward` plugin through the `reward_fn` pipeline double-counted every capture / death / obstacle / step-cost signal.

## Changes

- **`core/gridworld.py`**: add `include_base_reward: bool = True` constructor param (backward compatible) and gate the `base_reward()` call in `step()` on it; when off, `step()` emits `0.0` per agent instead of the base signal.
- **`scripts/run_from_config.py`**: wire `include_base_reward` from `rewards.base.enabled`, so the config flag is finally functional.
- **`rewards/base_reward.py`**: document `BaseReward` as deprecated for use via `reward_fn` (toggle through the flag instead) to prevent re-introducing the double count.
- **`tests/test_core_gridworld.py`**: regression tests (default is `True`; `False` zeroes the base signal; `False` still applies `reward_fn` shaping).

## Verification

Full suite: 289 passed. flake8 clean.

## Issue

Partially addresses #32: this fixes the no-op flag and the double count. It does **not** yet demote the base reward to a first-class plugin (the deeper architectural change #32 also mentions), so `base_reward()` still lives in `core/`.

## Note for reviewers

This touches `src/multi_agent_package/core/`, so the `core-guard` CI check will fail by design. This is an intentional maintainer-approved core change; merge accordingly.