### PR TITLE
fix: make base reward a first-class plugin (closes #32)

### DIFF
--- a/src/multi_agent_package/core/gridworld.py
+++ b/src/multi_agent_package/core/gridworld.py
@@ -281,8 +281,13 @@ class GridWorldEnv(gym.Env):
         self._captures_total += self._captures_this_step
         self._episode_steps += 1
 
-        # rewards
-        rewards = self.base_reward()
+        # rewards: step() applies no reward on its own. All reward signal,
+        # including the base capture/obstacle/step-cost reward, is supplied by
+        # the reward_fn pipeline via the BaseReward plugin (added by
+        # run_from_config when rewards.base.enabled is true). This gives the
+        # base reward exactly one application path, so it can never be
+        # double-counted. See rewards/base_reward.py and issue #32.
+        rewards = {ag.agent_name: 0.0 for ag in self.agents}
 
         if self.reward_fn is not None:
             custom = self.reward_fn(self)

--- a/src/multi_agent_package/rewards/base_reward.py
+++ b/src/multi_agent_package/rewards/base_reward.py
@@ -1,7 +1,15 @@
 """
-Wrapper for GridWorldEnv.base_reward().
+BaseReward plugin: the canonical capture / obstacle / step-cost signal.
 
-This allows base rewards to be toggled via config.
+This is the ONLY path by which the base reward enters an experiment.
+GridWorldEnv.step() applies no reward on its own; run_from_config adds this
+plugin to the reward pipeline when rewards.base.enabled is true, and toggling
+that flag is how the base reward is enabled or disabled. Because there is a
+single application path, the base reward can no longer be double-counted
+(issue #32).
+
+Custom run scripts that assemble their own reward_fn must include this plugin
+if they want the base signal; otherwise the environment produces no reward.
 """
 
 from multi_agent_package.rewards.base import RewardFunction

--- a/src/multi_agent_package/scripts/run_from_config.py
+++ b/src/multi_agent_package/scripts/run_from_config.py
@@ -143,9 +143,12 @@ def build_environment(configs: dict) -> GridWorldEnv:
     # -----------------------------
     reward_fns = []
 
-    # base_reward() is called internally by gridworld.step() — do NOT add it
-    # here or every capture/death signal gets counted twice.
-    _ = reward_cfg["rewards"]["base"]["enabled"]  # validate key exists
+    # The base reward is a first-class plugin like any other: it enters the
+    # pipeline here (and only here) when rewards.base.enabled is true.
+    # gridworld.step() applies no reward on its own, so there is exactly one
+    # application path and the base reward cannot be double-counted (issue #32).
+    if reward_cfg["rewards"]["base"]["enabled"]:
+        reward_fns.append(get_reward_function("base"))
 
     for r in reward_cfg["rewards"].get("shaping", []):
         reward_fns.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,7 @@ def dqn_env(one_predator_one_prey):
     """5×5 env with local_only observation + discrete_5 actions wired for DQN."""
     from multi_agent_package.observations.local_only import LocalOnlyObservation
     from multi_agent_package.actions.discrete_actions import DiscreteActionSpace
+    from multi_agent_package.rewards.base_reward import BaseReward
 
     env = GridWorldEnv(
         agents=one_predator_one_prey,
@@ -174,4 +175,7 @@ def dqn_env(one_predator_one_prey):
     env.observation_builder = observation_builder.build
     env.observation_encoder = observation_builder.encode
     env.action_space_plugin = DiscreteActionSpace()
+    # base reward now enters through the plugin pipeline, not gridworld.step();
+    # attach it so training sees the capture/step-cost signal (issue #32)
+    env.reward_fn = BaseReward(weight=1.0).compute
     return env

--- a/tests/test_baselines_cql.py
+++ b/tests/test_baselines_cql.py
@@ -10,6 +10,7 @@ import pytest
 
 from multi_agent_package.core.agent import Agent
 from multi_agent_package.core.gridworld import GridWorldEnv
+from multi_agent_package.rewards.base_reward import BaseReward
 from baselines.CQL.cql import CQL
 
 # ------------------------------------------------------------------
@@ -31,9 +32,13 @@ def make_env(n_pred=1, n_prey=1, size=5, seed=0):
         agents.append(
             Agent(agent_type="prey", agent_team=f"prey_{i}", agent_name=f"prey_{i}")
         )
-    return GridWorldEnv(
+    env = GridWorldEnv(
         agents=agents, size=size, perc_num_obstacle=0, render_mode=None, seed=seed
     )
+    # base reward now enters through the plugin pipeline, not gridworld.step();
+    # attach it so training sees the capture/step-cost signal (issue #32)
+    env.reward_fn = BaseReward(weight=1.0).compute
+    return env
 
 
 def base_config(**overrides):

--- a/tests/test_baselines_iql.py
+++ b/tests/test_baselines_iql.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from multi_agent_package.core.agent import Agent
 from multi_agent_package.core.gridworld import GridWorldEnv
+from multi_agent_package.rewards.base_reward import BaseReward
 from baselines.IQL.iql import IQL
 
 # ------------------------------------------------------------------
@@ -21,9 +22,13 @@ def make_env(seed=42):
         Agent(agent_type="predator", agent_team="predator_1", agent_name="pred_1"),
         Agent(agent_type="prey", agent_team="prey_1", agent_name="prey_1"),
     ]
-    return GridWorldEnv(
+    env = GridWorldEnv(
         agents=agents, size=5, perc_num_obstacle=0, render_mode=None, seed=seed
     )
+    # base reward now enters through the plugin pipeline, not gridworld.step();
+    # attach it so training sees the capture/step-cost signal (issue #32)
+    env.reward_fn = BaseReward(weight=1.0).compute
+    return env
 
 
 def base_config(**overrides):

--- a/tests/test_baselines_mixed.py
+++ b/tests/test_baselines_mixed.py
@@ -10,6 +10,7 @@ import pytest
 
 from multi_agent_package.core.agent import Agent
 from multi_agent_package.core.gridworld import GridWorldEnv
+from multi_agent_package.rewards.base_reward import BaseReward
 from baselines.MIXED.mix_train import MixedTrainer
 
 # ------------------------------------------------------------------
@@ -23,9 +24,13 @@ def make_env(seed=0):
         Agent(agent_type="predator", agent_team="predator_2", agent_name="pred_2"),
         Agent(agent_type="prey", agent_team="prey_1", agent_name="prey_1"),
     ]
-    return GridWorldEnv(
+    env = GridWorldEnv(
         agents=agents, size=6, perc_num_obstacle=0, render_mode=None, seed=seed
     )
+    # base reward now enters through the plugin pipeline, not gridworld.step();
+    # attach it so training sees the capture/step-cost signal (issue #32)
+    env.reward_fn = BaseReward(weight=1.0).compute
+    return env
 
 
 def base_config(predator_algo="cql", prey_algo="iql", **overrides):

--- a/tests/test_core_gridworld.py
+++ b/tests/test_core_gridworld.py
@@ -135,16 +135,30 @@ class TestStepStructure:
 
 
 # ------------------------------------------------------------------
-# Step cost from base_reward
+# Reward is supplied only through reward_fn (base reward is a plugin)
 # ------------------------------------------------------------------
 
 
 class TestStepCost:
-    def test_predator_gets_step_cost(self):
+    def test_step_applies_no_reward_without_reward_fn(self):
+        # gridworld.step() supplies no reward on its own; all reward comes
+        # through reward_fn. This is what makes the base reward (a plugin) have
+        # a single application path and prevents double-counting (issue #32).
         env = make_env(perc_obstacle=0)
         obs, _ = env.reset()
         out = env.step({aid: 4 for aid in obs})
-        # predator should lose 5 per step (no capture, no obstacle)
+        assert set(out["reward"]) == set(obs)
+        assert all(v == 0.0 for v in out["reward"].values())
+
+    def test_base_reward_plugin_applies_step_cost_once(self):
+        # With the BaseReward plugin as the reward_fn, the predator's -5 step
+        # cost is applied exactly once (not -10).
+        from multi_agent_package.rewards.base_reward import BaseReward
+
+        env = make_env(perc_obstacle=0)
+        env.reward_fn = BaseReward(weight=1.0).compute
+        obs, _ = env.reset()
+        out = env.step({aid: 4 for aid in obs})
         assert out["reward"]["pred_1"] == pytest.approx(-5.0)
 
 
@@ -273,8 +287,8 @@ class TestExtensionHooks:
         env.reward_fn = lambda e: {ag.agent_name: 100.0 for ag in e.agents}
         obs, _ = env.reset()
         out = env.step({aid: 4 for aid in obs})
-        # base has -5 for predator, custom adds +100 → 95
-        assert out["reward"]["pred_1"] == pytest.approx(95.0)
+        # step() applies no base reward itself, so only the custom fn counts
+        assert out["reward"]["pred_1"] == pytest.approx(100.0)
 
     def test_custom_observation_builder_called(self):
         env = make_env(perc_obstacle=0)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -188,6 +188,45 @@ class TestBuildEnvironment:
 
 
 # ------------------------------------------------------------------
+# Base reward enters only through the plugin pipeline (issue #32)
+# ------------------------------------------------------------------
+
+
+class TestBaseRewardIsPluginDriven:
+    def _build(self, base_enabled):
+        from multi_agent_package.scripts.run_from_config import (
+            load_all_configs,
+            build_environment,
+        )
+
+        configs = load_all_configs(experiment_file="experiment_iql.yaml")
+        configs["env"]["env"]["render_mode"] = None
+        configs["rewards"]["rewards"]["base"]["enabled"] = base_enabled
+        return build_environment(configs)
+
+    def _first_step_reward(self, env):
+        obs, _ = env.reset()
+        return env.step({aid: 4 for aid in obs})["reward"]
+
+    def test_base_enabled_adds_step_cost(self):
+        # With base enabled, a NOOP predator incurs the negative base step
+        # cost on top of shaping; disabling base removes exactly that
+        # component. This is the single-application-path guarantee of #32.
+        on = self._first_step_reward(self._build(True))
+        off = self._first_step_reward(self._build(False))
+        preds = [k for k in on if k.startswith("pred")]
+        assert preds, "expected predator agents in the IQL config"
+        for k in preds:
+            assert on[k] < off[k], f"base reward not applied for {k}"
+
+    def test_base_disabled_leaves_only_shaping(self):
+        # Disabling base must not zero out shaping (prey survival shaping stays).
+        off = self._first_step_reward(self._build(False))
+        prey = [v for k, v in off.items() if k.startswith("prey")]
+        assert prey and all(v > 0 for v in prey)
+
+
+# ------------------------------------------------------------------
 # End-to-end training: IQL
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem (issue #32)

`GridWorldEnv.step()` applied `base_reward()` unconditionally. Consequences:
- `rewards.base.enabled` was a dead config key (read, never acted on).
- If the `BaseReward` plugin was also added to the reward pipeline, every capture/death/obstacle signal was double-counted.
- Disabling the base reward required editing `core/gridworld.py`, a file contributors are told never to touch.

## Fix: single application path

The base reward becomes a first-class plugin like `predator_distance` or `survival`, with exactly one application path:

- **`core/gridworld.py`**: `step()` applies no reward on its own; all reward comes through `reward_fn`. `base_reward()` stays as the helper the plugin calls.
- **`scripts/run_from_config.py`**: the `BaseReward` plugin is added to the reward pipeline when `rewards.base.enabled` is true (and only there).
- **`rewards/base_reward.py`**: documented as the canonical, only path for the base signal.

Because there is one application path, the base reward can no longer be double-counted, `rewards.base.enabled` genuinely toggles it, and toggling requires no core edit.

## Behavioral note

The base reward is now **opt-in via the pipeline**. Any script that builds its own `reward_fn` (rather than using `run_from_config`) must include the `BaseReward` plugin to get the base signal. The baseline/DQN test fixtures were updated accordingly.

## Verification

- Full suite: **294 passed** (added core reward tests + integration regression tests for the enabled/disabled pipeline).
- End-to-end (`build_environment`, IQL, headless): with base enabled a NOOP predator gets shaping + base step-cost; with base disabled it gets shaping only; both train. No double-count.

## Note for reviewers

This touches `src/multi_agent_package/core/`, so the `core-guard` CI check will fail by design. Intentional maintainer-approved core change; merge accordingly.