### PR TITLE
ci: use editable install, drop PYTHONPATH

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -e ".[dev]"
 
       - name: Check formatting with Black
         run: black --check .
@@ -41,8 +41,6 @@ jobs:
         run: flake8 .
 
       - name: Run Pylint
-        env:
-          PYTHONPATH: src
         run: pylint src
 
   test:
@@ -67,11 +65,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -e ".[dev]"
 
       - name: Run tests
-        env:
-          PYTHONPATH: src
         run: pytest tests/ -q
 
   # Enforces CONTRIBUTING.md's "Golden Rule": core/gridworld.py and


### PR DESCRIPTION
## What

`pyproject.toml` now provides a build backend, so `pip install -e .` makes the
package importable. This aligns CI with the documented install path.

## Changes
- `lint` and `test` jobs install with `pip install -e ".[dev]"` instead of
  `pip install -r requirements*.txt`.
- Remove the `PYTHONPATH: src` env from the pylint and pytest steps.
- Black, flake8, pylint, and the test suite are otherwise unchanged and still run.

## Verification
Run locally without `PYTHONPATH`: `pylint src` → 10.00/10, `black --check .` clean,
`flake8 .` clean, `pytest tests/ -q` → 315 passed.
