### PR TITLE
ci(docs): deploy the docs site on push to STRP as well as main

### DIFF
--- a/.github/workflows/docs-mkdocs.yml
+++ b/.github/workflows/docs-mkdocs.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Docs (MkDocs)
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, STRP ]
 
 permissions:
   contents: read


### PR DESCRIPTION
STRP is the active trunk (and now the default branch), so publish the docs site from STRP too instead of only on main. Otherwise the live GitHub Pages site lags the trunk until the next STRP -> main release.