### PR TITLE
feat: add A2C algorithm implementation with actor-critic networks and updated README.md

### DIFF
--- a/configs/experiment_a2c.yaml
+++ b/configs/experiment_a2c.yaml
@@ -1,0 +1,20 @@
+# configs/experiment_a2c.yaml
+experiment:
+  algorithm:
+    name: a2c
+    params:
+      gamma: 0.99
+      hidden_layers: [128, 128]   # shared shape for both actor and critic networks
+
+      actor_learning_rate: 0.0003
+      critic_learning_rate: 0.001
+
+      n_steps: 5              # rollout length between actor/critic updates
+      entropy_coef: 0.01      # exploration bonus: higher = more random policy for longer
+      value_loss_coef: 0.5    # weight of the critic's MSE loss relative to the actor's loss
+      grad_clip: 5.0
+
+      episodes: 1000
+      seed: 42
+      device: "cpu"
+      curves_path: "training_curves_a2c.csv"

--- a/src/baselines/A2C/a2c.py
+++ b/src/baselines/A2C/a2c.py
@@ -1,0 +1,507 @@
+# src/baselines/A2C/a2c.py
+"""
+Independent Advantage Actor-Critic (A2C) baseline.
+
+Independent-learning pattern -- one learner PER AGENT --
+each learner is now a (actor, critic) pair:
+
+    A2C   : per agent -> actor network + critic network               (on-policy)
+
+A2C collects a short ROLLOUT of `n_steps` transitions, computes an 
+n-step bootstrapped return for each one, and updates immediately. 
+
+Observations are converted to fixed-length numeric vectors via the
+environment's observation_encoder: attach an
+observation builder's encode() method to env.observation_encoder
+before constructing A2C (run_from_config.build_environment does this).
+"""
+
+from __future__ import annotations
+
+
+
+import csv
+import logging
+import os
+import pickle
+import warnings
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from numpy.random import default_rng
+
+from baselines.base import BaseAlgorithm
+from baselines.registry.algorithm_registry import register
+from baselines.A2C.actor_network import ActorNetwork
+from baselines.A2C.critic_network import CriticNetwork
+
+LOGGER = logging.getLogger("a2c")
+
+
+class A2C(BaseAlgorithm):
+    """Independent A2C: one actor + one critic per agent, updated on an n-step rollout."""
+
+    def __init__(self, env, config: dict):
+        super().__init__(env, config)
+
+        # ---- hyperparameters from config --------------------------------
+
+        self.gamma = float(config.get("gamma", 0.99))
+        self.episodes = int(config.get("episodes", 1000))
+        self.hidden_layers = [int(v) for v in config.get("hidden_layers", [128, 128])]
+        self.n_steps = int(config.get("n_steps", 5))
+        self.entropy_coef = float(config.get("entropy_coef", 0.01))
+        self.value_loss_coef = float(config.get("value_loss_coef", 0.5))
+        self.grad_clip = float(config.get("grad_clip", 5.0))
+
+        # separate learning rates: the critic usually wants to learn faster/
+        # more stably than the actor, since the actor's gradient direction
+        # depends on the critic already being roughly correct.
+        actor_lr = config.get("actor_learning_rate", config.get("learning_rate", 3e-4))
+        critic_lr = config.get("critic_learning_rate", config.get("learning_rate", 1e-3))
+        self.actor_lr = float(actor_lr)
+        self.critic_lr = float(critic_lr)
+
+        self.device = torch.device(config.get("device", "cpu"))
+        self.verbose = bool(config.get("verbose", True))
+        self.log_interval = int(config.get("log_interval", 10))
+        self.debug_first_episode = bool(config.get("debug_first_episode", True))
+        self.save_path = config.get("save_path", None)
+        self.curves_path: Optional[str] = config.get("curves_path", None)
+
+        # If True, select_actions() acts greedily (argmax over the policy's
+        # probabilities) instead of sampling. Exploration comes from sampling 
+        # the stochastic policy. Evaluation scripts set this to True.
+        self.greedy_eval = bool(config.get("greedy_eval", False))
+
+        if self.n_steps <= 0:
+            raise ValueError(f"n_steps must be positive, got {self.n_steps}")
+
+        seed = config.get("seed", None)
+        self.rng = default_rng(seed)
+        if seed is not None:
+            torch.manual_seed(int(seed))
+
+        # ---- observation encoder contract --------
+
+        self.observation_encoder = getattr(self.env, "observation_encoder", None)
+        if self.observation_encoder is None:
+            raise ValueError(
+                "Environment is missing observation_encoder. Attach an observation "
+                "builder's encode() method to env.observation_encoder before "
+                "constructing A2C (see run_from_config.build_environment)."
+            )
+
+        initial_obs, _ = self.env.reset()
+        self.agent_ids = list(initial_obs.keys())
+        self.state_dim = self._encode_observation(initial_obs[self.agent_ids[0]]).shape[0]
+        self.action_dim = self._resolve_action_dim(config)
+
+        self._build_learners()
+        self._train_steps = 0
+
+        self._debug(
+            "Initialized A2C | "
+            f"agents={self.agent_ids} | state_dim={self.state_dim} | "
+            f"action_dim={self.action_dim} | device={self.device} | "
+            f"n_steps={self.n_steps} | entropy_coef={self.entropy_coef}"
+        )
+
+    # ------------------------------------------------------------------
+    # Setup helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_action_dim(self, config: dict) -> int:
+        """Infer action_dim from the env's action plugin, or validate it if configured.
+        Identical logic to DQN's, kept local so A2C stays self-contained."""
+        plugin = getattr(self.env, "action_space_plugin", None)
+        plugin_n_actions = (
+            int(plugin.n_actions) if plugin is not None else int(self.env.action_space.n)
+        )
+
+        configured = config.get("action_dim", None)
+        if configured is None:
+            return plugin_n_actions
+
+        configured = int(configured)
+        if configured != plugin_n_actions:
+            raise ValueError(
+                f"A2C config error: 'action_dim'={configured} does not match the "
+                f"environment's action space size ({plugin_n_actions}). Fix "
+                "'action_dim' in your experiment YAML, or remove it entirely so "
+                "it gets inferred automatically."
+            )
+        return configured
+
+    def _build_learners(self) -> None:
+        self.actors = {}
+        self.critics = {}
+        self.actor_optimizers = {}
+        self.critic_optimizers = {}
+
+        for agent_id in self.agent_ids:
+            self.actors[agent_id] = ActorNetwork(
+                self.state_dim, self.hidden_layers, self.action_dim
+            ).to(self.device)
+            self.critics[agent_id] = CriticNetwork(
+                self.state_dim, self.hidden_layers
+            ).to(self.device)
+
+            self.actor_optimizers[agent_id] = optim.Adam(
+                self.actors[agent_id].parameters(), lr=self.actor_lr
+            )
+            self.critic_optimizers[agent_id] = optim.Adam(
+                self.critics[agent_id].parameters(), lr=self.critic_lr
+            )
+
+    def _debug(self, message: str) -> None:
+        if self.verbose:
+            print(f"[A2C] {message}")
+
+    def _empty_rollout(self) -> dict:
+        return {
+            aid: {"log_probs": [], "values": [], "rewards": [], "entropies": []}
+            for aid in self.agent_ids
+        }
+
+    # ------------------------------------------------------------------
+    # Observation encoding
+    # ------------------------------------------------------------------
+
+    def _encode_observation(self, obs) -> np.ndarray:
+        encoded = self.observation_encoder(obs, self.env)
+        return np.asarray(encoded, dtype=np.float32).reshape(-1)
+
+    def _validate_state_shape(self, agent_id: str, state: np.ndarray) -> None:
+        if state.shape[0] != self.state_dim:
+            raise ValueError(
+                f"A2C expected state_dim={self.state_dim}, but agent {agent_id!r} "
+                f"produced state_dim={state.shape[0]}. This usually means the "
+                "observation plugin is returning variable-length observations."
+            )
+
+    # ------------------------------------------------------------------
+    # Action selection (BaseAlgorithm interface)
+    # ------------------------------------------------------------------
+
+    def select_actions(self, observations: dict) -> dict:
+        """
+        Public, gradient-free action selection -- used by BaseAlgorithm.evaluate()
+        and by anything outside the training loop. The training loop itself does
+        NOT call this method: it needs log_prob/value/entropy WITH gradients
+        attached, so it runs the same forward pass directly (see _train_loop).
+        """
+        actions = {}
+        with torch.no_grad():
+            for agent_id, obs in observations.items():
+                state = self._encode_observation(obs)
+                state_t = torch.from_numpy(state).float().unsqueeze(0).to(self.device)
+                dist = self.actors[agent_id].distribution(state_t)
+                if self.greedy_eval:
+                    action = torch.argmax(dist.probs, dim=1)
+                else:
+                    action = dist.sample()
+                actions[agent_id] = int(action.item())
+        return actions
+
+    # ------------------------------------------------------------------
+    # Learning
+    # ------------------------------------------------------------------
+
+    def _optimize_agent(self, agent_id: str, traj: dict, bootstrap_value: float):
+        """
+        Turns one agent's n-step rollout into an actor update and a critic
+        update. Returns (actor_loss, critic_loss, mean_entropy) as floats for
+        logging.
+
+        n-step return:  R_t = r_t + gamma*r_{t+1} + ... + gamma^k * V(s_{t+k})
+        Bootstrap value is 0 if the episode ended inside this rollout
+        (nothing beyond a terminal state contributes future reward),
+        otherwise it's the critic's own estimate of the state we stopped at.
+        """
+        rewards = traj["rewards"]
+
+        returns = []
+        R = bootstrap_value
+        for r in reversed(rewards):
+            R = r + self.gamma * R
+            returns.insert(0, R)
+        returns_t = torch.tensor(returns, dtype=torch.float32, device=self.device)
+
+        values_t = torch.cat(traj["values"])      # keeps grad -> critic params
+        log_probs_t = torch.cat(traj["log_probs"])  # keeps grad -> actor params
+        entropies_t = torch.cat(traj["entropies"])
+
+        # detach() is essential:
+        # the actor should be pushed by the SIGN and SIZE of the advantage,
+        # not by trying to change the critic's value through this path.
+        advantages = returns_t - values_t.detach()
+
+        actor_loss = -(log_probs_t * advantages).mean() - self.entropy_coef * entropies_t.mean()
+        critic_loss = nn.MSELoss()(values_t, returns_t)
+
+        self.actor_optimizers[agent_id].zero_grad()
+        actor_loss.backward()
+        torch.nn.utils.clip_grad_norm_(self.actors[agent_id].parameters(), self.grad_clip)
+        self.actor_optimizers[agent_id].step()
+
+        self.critic_optimizers[agent_id].zero_grad()
+        (self.value_loss_coef * critic_loss).backward()
+        torch.nn.utils.clip_grad_norm_(self.critics[agent_id].parameters(), self.grad_clip)
+        self.critic_optimizers[agent_id].step()
+
+        self._train_steps += 1
+
+        return float(actor_loss.item()), float(critic_loss.item()), float(entropies_t.mean().item())
+
+    # ------------------------------------------------------------------
+    # Training loop (BaseAlgorithm interface)
+    # ------------------------------------------------------------------
+
+    def train(self):
+        csv_file = None
+        csv_writer = None
+        if self.curves_path:
+            os.makedirs(os.path.dirname(self.curves_path) or ".", exist_ok=True)
+            csv_file = open(self.curves_path, "w", newline="")
+            reward_cols = [f"{aid}_reward" for aid in self.agent_ids]
+            actor_loss_cols = [f"{aid}_actor_loss" for aid in self.agent_ids]
+            critic_loss_cols = [f"{aid}_critic_loss" for aid in self.agent_ids]
+            entropy_cols = [f"{aid}_entropy" for aid in self.agent_ids]
+            csv_writer = csv.DictWriter(
+                csv_file,
+                fieldnames=["episode"] + reward_cols + actor_loss_cols
+                + critic_loss_cols + entropy_cols,
+            )
+            csv_writer.writeheader()
+
+        self._debug(f"Starting training for {self.episodes} episodes")
+        try:
+            self._train_loop(csv_writer)
+        finally:
+            if csv_file:
+                csv_file.close()
+
+        if self.save_path:
+            self.save(self.save_path)
+
+    def _act_with_grad(self, agent_id: str, obs) -> tuple:
+        """Forward pass WITH gradient tracking -- used only inside the
+        training loop, where log_prob/value/entropy must stay part of the
+        autograd graph so _optimize_agent can backpropagate through them."""
+        state = self._encode_observation(obs)
+        self._validate_state_shape(agent_id, state)
+        state_t = torch.from_numpy(state).float().unsqueeze(0).to(self.device)
+
+        dist = self.actors[agent_id].distribution(state_t)
+        action = dist.sample()
+        log_prob = dist.log_prob(action)
+        entropy = dist.entropy()
+        value = self.critics[agent_id](state_t).squeeze(1)
+
+        return int(action.item()), log_prob, entropy, value
+
+    def _train_loop(self, csv_writer) -> None:
+        for episode in range(self.episodes):
+            observations, _ = self.env.reset()
+            episode_rewards = {aid: 0.0 for aid in self.agent_ids}
+            episode_actor_losses = {aid: [] for aid in self.agent_ids}
+            episode_critic_losses = {aid: [] for aid in self.agent_ids}
+            episode_entropies = {aid: [] for aid in self.agent_ids}
+
+            rollout = self._empty_rollout()
+            done = False
+            step_count = 0
+
+            while not done:
+                actions = {}
+                for agent_id in self.agent_ids:
+                    action, log_prob, entropy, value = self._act_with_grad(
+                        agent_id, observations[agent_id]
+                    )
+                    actions[agent_id] = action
+                    rollout[agent_id]["log_probs"].append(log_prob)
+                    rollout[agent_id]["values"].append(value)
+                    rollout[agent_id]["entropies"].append(entropy)
+
+                step_out = self.env.step(actions)
+                next_observations = step_out["obs"]
+                rewards = step_out["reward"]
+                done = bool(step_out["terminated"] or step_out["truncated"])
+
+                for agent_id in self.agent_ids:
+                    r = float(rewards[agent_id])
+                    rollout[agent_id]["rewards"].append(r)
+                    episode_rewards[agent_id] += r
+
+                    if episode == 0 and step_count == 0 and self.debug_first_episode:
+                        self._debug(
+                            f"First transition | agent={agent_id} | "
+                            f"action={actions[agent_id]} | reward={r:.3f} | done={done}"
+                        )
+
+                observations = next_observations
+                step_count += 1
+
+                # Update every n_steps, or immediately at episode end (bootstraps 
+                # from 0 instead of from V(s_next)).
+                ready_to_update = (step_count % self.n_steps == 0) or done
+                if ready_to_update:
+                    for agent_id in self.agent_ids:
+                        if not rollout[agent_id]["rewards"]:
+                            continue  # nothing collected for this agent yet
+
+                        if done:
+                            bootstrap_value = 0.0
+                        else:
+                            with torch.no_grad():
+                                next_state = self._encode_observation(observations[agent_id])
+                                next_state_t = torch.from_numpy(next_state).float().unsqueeze(0).to(self.device)
+                                bootstrap_value = float(
+                                    self.critics[agent_id](next_state_t).item()
+                                )
+
+                        actor_loss, critic_loss, mean_entropy = self._optimize_agent(
+                            agent_id, rollout[agent_id], bootstrap_value
+                        )
+                        episode_actor_losses[agent_id].append(actor_loss)
+                        episode_critic_losses[agent_id].append(critic_loss)
+                        episode_entropies[agent_id].append(mean_entropy)
+
+                    rollout = self._empty_rollout()
+
+            if (episode + 1) % self.log_interval == 0:
+                reward_str = ", ".join(
+                    f"{aid}={value:.2f}" for aid, value in episode_rewards.items()
+                )
+                self._debug(
+                    f"Episode {episode + 1}/{self.episodes} | steps={step_count} | "
+                    f"rewards: {reward_str}"
+                )
+
+            if csv_writer:
+                row: dict = {"episode": episode + 1}
+                for aid in self.agent_ids:
+                    row[f"{aid}_reward"] = round(episode_rewards[aid], 4)
+                    a_losses = episode_actor_losses[aid]
+                    c_losses = episode_critic_losses[aid]
+                    ent = episode_entropies[aid]
+                    row[f"{aid}_actor_loss"] = round(float(np.mean(a_losses)), 6) if a_losses else ""
+                    row[f"{aid}_critic_loss"] = round(float(np.mean(c_losses)), 6) if c_losses else ""
+                    row[f"{aid}_entropy"] = round(float(np.mean(ent)), 6) if ent else ""
+                csv_writer.writerow(row)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def save(self, path: str) -> None:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        payload = {
+            "config": self.config,
+            "agent_ids": self.agent_ids,
+            "state_dim": self.state_dim,
+            "action_dim": self.action_dim,
+            "actor_state_dicts": {aid: net.state_dict() for aid, net in self.actors.items()},
+            "critic_state_dicts": {aid: net.state_dict() for aid, net in self.critics.items()},
+        }
+        with open(path, "wb") as fh:
+            pickle.dump(payload, fh)
+        LOGGER.info("Saved A2C checkpoint -> %s", path)
+        self._debug(f"Saved A2C checkpoint -> {path}")
+
+    @classmethod
+    def load(cls, env, config: dict, path: str) -> "A2C":
+        instance = cls(env, config)
+        with open(path, "rb") as fh:
+            payload = pickle.load(fh)
+
+        for agent_id in instance.agent_ids:
+            if agent_id in payload["actor_state_dicts"]:
+                instance.actors[agent_id].load_state_dict(payload["actor_state_dicts"][agent_id])
+            if agent_id in payload["critic_state_dicts"]:
+                instance.critics[agent_id].load_state_dict(payload["critic_state_dicts"][agent_id])
+
+        LOGGER.info("Loaded A2C checkpoint from %s", path)
+        return instance
+
+
+if __name__ != "__main__":
+    register("a2c", A2C)
+
+
+# ------------------------------------------------------------------
+# Standalone CLI -- python -m baselines.A2C.a2c [--mode train|eval]
+# (for quick manual testing without YAML configs)
+# ------------------------------------------------------------------
+if __name__ == "__main__":
+    import argparse
+
+    from multi_agent_package.core.agent import Agent
+    from multi_agent_package.core.gridworld import GridWorldEnv
+    from multi_agent_package.registry import get_action_space, get_observation_builder
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(levelname)s - %(message)s",
+        datefmt="%d-%m-%Y %H:%M:%S",
+    )
+
+    p = argparse.ArgumentParser("Independent A2C — train or evaluate")
+    p.add_argument("--mode", choices=["train", "eval"], default="train")
+    p.add_argument("--episodes", type=int, default=1000)
+    p.add_argument("--size", type=int, default=8)
+    p.add_argument("--predators", type=int, default=1)
+    p.add_argument("--preys", type=int, default=1)
+    p.add_argument("--observation", type=str, default="local_only")
+    p.add_argument("--action-space", type=str, default="discrete_5")
+    p.add_argument("--hidden-layers", type=int, nargs="+", default=[128, 128])
+    p.add_argument("--n-steps", type=int, default=5)
+    p.add_argument("--actor-lr", type=float, default=3e-4)
+    p.add_argument("--critic-lr", type=float, default=1e-3)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--save-path", type=str, default="trained_a2c.pkl")
+    p.add_argument("--load-path", type=str, default=None)
+    p.add_argument("--render", action="store_true")
+    args = p.parse_args()
+
+    agents = []
+    for i in range(1, args.preys + 1):
+        agents.append(Agent(agent_name=f"prey_{i}", agent_team=i, agent_type="prey"))
+    for i in range(1, args.predators + 1):
+        agents.append(Agent(agent_name=f"predator_{i}", agent_team=i, agent_type="predator"))
+
+    render = "human" if (args.mode == "eval" and args.render) else None
+    env = GridWorldEnv(
+        agents=agents, render_mode=render, size=args.size, perc_num_obstacle=10, seed=args.seed
+    )
+
+    observation_builder = get_observation_builder(args.observation)
+    env.observation_builder = observation_builder.build
+    env.observation_encoder = observation_builder.encode
+    env.action_space_plugin = get_action_space(args.action_space)
+
+    config = {
+        "hidden_layers": args.hidden_layers,
+        "n_steps": args.n_steps,
+        "actor_learning_rate": args.actor_lr,
+        "critic_learning_rate": args.critic_lr,
+        "episodes": args.episodes,
+        "seed": args.seed,
+        "greedy_eval": args.mode == "eval",
+    }
+
+    if args.mode == "train":
+        algo = A2C(env, config)
+        algo.train()
+        algo.save(args.save_path)
+    else:
+        if not args.load_path:
+            raise SystemExit("--load-path is required for --mode eval")
+        algo = A2C.load(env, config, args.load_path)
+        algo.evaluate(episodes=args.episodes)
+
+    env.close()

--- a/src/baselines/A2C/actor_network.py
+++ b/src/baselines/A2C/actor_network.py
@@ -1,0 +1,56 @@
+# src/baselines/A2C/actor_network.py
+"""
+Configurable feedforward policy (actor) network for discrete action
+spaces (PyTorch).
+
+input_dim -> hidden_layers -> output_dim),
+the output layer here is interpreted
+as unnormalized action LOGITS
+
+Wrapping the logits in torch.distributions.Categorical gives everything
+A2C needs from one forward pass:
+    dist.sample()    -> stochastic action (exploration)
+    dist.log_prob(a) -> log pi(a|s), used in the policy-gradient loss
+    dist.entropy()   -> entropy bonus, keeps the policy from collapsing
+                        to a single action too early
+"""
+
+from typing import List
+
+import torch
+import torch.nn as nn
+from torch.distributions import Categorical
+
+
+class ActorNetwork(nn.Module):
+    def __init__(self, input_dim: int, hidden_layers: List[int], output_dim: int):
+        super().__init__()
+        if input_dim <= 0:
+            raise ValueError(f"input_dim must be positive, got {input_dim}")
+        if output_dim <= 0:
+            raise ValueError(f"output_dim must be positive, got {output_dim}")
+        if not hidden_layers or any(h <= 0 for h in hidden_layers):
+            raise ValueError(
+                f"hidden_layers must be a non-empty list of positive ints, got {hidden_layers}"
+            )
+
+        layers: List[nn.Module] = []
+        in_dim = int(input_dim)
+        for hidden_dim in hidden_layers:
+            layers.append(nn.Linear(in_dim, int(hidden_dim)))
+            layers.append(nn.ReLU())
+            in_dim = int(hidden_dim)
+        # Linear output -- these are LOGITS, not probabilities. Categorical
+        # applies softmax internally
+        layers.append(nn.Linear(in_dim, int(output_dim)))
+
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Raw action logits, shape (batch, output_dim)."""
+        return self.model(x)
+
+    def distribution(self, x: torch.Tensor) -> Categorical:
+        """Wrap forward()'s logits in a Categorical distribution."""
+        logits = self.forward(x)
+        return Categorical(logits=logits)

--- a/src/baselines/A2C/critic_network.py
+++ b/src/baselines/A2C/critic_network.py
@@ -1,0 +1,37 @@
+# src/baselines/A2C/critic_network.py
+"""
+Configurable feedforward state-value (critic) network (PyTorch).
+
+Estimates V(s), a single scalar per state. Output layer is linear 
+(handle negative penalties)
+"""
+
+from typing import List
+
+import torch
+import torch.nn as nn
+
+
+class CriticNetwork(nn.Module):
+    def __init__(self, input_dim: int, hidden_layers: List[int]):
+        super().__init__()
+        if input_dim <= 0:
+            raise ValueError(f"input_dim must be positive, got {input_dim}")
+        if not hidden_layers or any(h <= 0 for h in hidden_layers):
+            raise ValueError(
+                f"hidden_layers must be a non-empty list of positive ints, got {hidden_layers}"
+            )
+
+        layers: List[nn.Module] = []
+        in_dim = int(input_dim)
+        for hidden_dim in hidden_layers:
+            layers.append(nn.Linear(in_dim, int(hidden_dim)))
+            layers.append(nn.ReLU())
+            in_dim = int(hidden_dim)
+        layers.append(nn.Linear(in_dim, 1))
+
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """V(s), shape (batch, 1)."""
+        return self.model(x)

--- a/src/baselines/README.md
+++ b/src/baselines/README.md
@@ -117,6 +117,8 @@ baselines/
 │
 ├── DQN/               # Deep Q-Network, PyTorch (dqn.py + CLI, q_network.py, replay_buffer.py)
 │
+├── A2C/               # Advantage Actor-Critic (a2c.py + actor_network.py + critic_network.py)
+│
 └── README.md
 ```
 
@@ -208,6 +210,30 @@ Algorithms must:
 * Function-approximation baseline instead of tabular Q-learning
 * Larger observation spaces where tabular state encoding becomes impractical
 * Studying Double/Dueling DQN variants against vanilla DQN
+
+---
+
+## 🟩 A2C — Advantage Actor-Critic
+
+* One actor (policy network) + one critic (state-value network) per agent
+* On-policy: no replay buffer -- learns directly from freshly-collected experience,
+  discarding it after each update  
+* Learns two things at once instead of one:
+  * The actor learns *what to do* (a probability distribution over actions)
+  * The critic learns *how good a state is* (a baseline used to reduce variance
+    in the actor's gradient, without introducing bias)
+* Exploration comes from sampling the stochastic policy (plus an entropy
+  bonus that discourages the policy from collapsing too early) -- there is no
+  epsilon schedule
+
+
+### When to Use
+
+* Studying on-policy vs off-policy learning dynamics
+* Environments/rewards where a stochastic policy is itself interesting
+  (e.g. mixed-strategy pursuit-evasion)
+* As the natural stepping stone toward A3C (parallel workers) and SAC
+  (off-policy actor-critic with entropy maximization)
 
 ---
 

--- a/src/baselines/__init__.py
+++ b/src/baselines/__init__.py
@@ -3,3 +3,4 @@ from baselines.IQL.iql import IQL  # noqa: F401
 from baselines.CQL.cql import CQL  # noqa: F401
 from baselines.MIXED.mix_train import MixedTrainer  # noqa: F401
 from baselines.DQN.dqn import DQN  # noqa: F401
+from baselines.A2C.a2c import A2C

--- a/src/multi_agent_package/scripts/run_a2c.py
+++ b/src/multi_agent_package/scripts/run_a2c.py
@@ -1,0 +1,68 @@
+# src/multi_agent_package/scripts/run_a2c.py
+"""
+Train or evaluate A2C using configs/experiment_a2c.yaml.
+
+Usage:
+    cd src
+    python -m multi_agent_package.scripts.run_a2c                      # train
+    python -m multi_agent_package.scripts.run_a2c --mode eval \\
+        --load-path trained_a2c.pkl
+"""
+
+import argparse
+import logging
+
+import baselines  # noqa: F401 — triggers auto-registration
+from baselines.A2C.a2c import A2C
+from multi_agent_package.scripts.run_from_config import (
+    load_all_configs,
+    build_environment,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] %(levelname)s - %(message)s",
+    datefmt="%d-%m-%Y %H:%M:%S",
+)
+
+EXPERIMENT_FILE = "experiment_a2c.yaml"
+
+
+def main():
+    p = argparse.ArgumentParser("Run A2C experiment")
+    p.add_argument("--mode", choices=["train", "eval"], default="train")
+    p.add_argument("--config-dir", default="configs")
+    p.add_argument("--save-path", default="trained_a2c.pkl")
+    p.add_argument("--load-path", default=None)
+    p.add_argument("--render", action="store_true",
+                   help="Enable pygame window during eval (requires a display)")
+    args = p.parse_args()
+
+    configs = load_all_configs(args.config_dir, EXPERIMENT_FILE)
+
+    if args.mode == "eval":
+        configs["env"]["env"]["render_mode"] = "human" if args.render else None
+
+    env = build_environment(configs)
+    algo_params = configs["experiment"]["experiment"]["algorithm"].get("params", {})
+
+    if args.mode == "eval":
+        # A2C exploration comes from sampling the
+        # policy. For evaluation we want the greedy (argmax) action instead.
+        algo_params = dict(algo_params, greedy_eval=True)
+
+    if args.mode == "train":
+        algo = A2C(env, algo_params)
+        algo.train()
+        algo.save(args.save_path)
+    else:
+        if not args.load_path:
+            raise SystemExit("--load-path is required for --mode eval")
+        algo = A2C.load(env, algo_params, args.load_path)
+        algo.evaluate()
+
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_baselines_a2c.py
+++ b/tests/test_baselines_a2c.py
@@ -1,0 +1,337 @@
+# tests/test_baselines_a2c.py
+"""
+Tests for A2C (Advantage Actor-Critic baseline).
+"""
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+
+from multi_agent_package.core.agent import Agent
+from multi_agent_package.core.gridworld import GridWorldEnv
+from multi_agent_package.observations.relative import RelativeObservation
+from baselines.A2C.a2c import A2C
+from baselines.A2C.actor_network import ActorNetwork
+from baselines.A2C.critic_network import CriticNetwork
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def make_env(n_pred=1, n_prey=1, size=5, seed=0, perc_obstacle=0, max_steps=50):
+    """
+    Builds a small env wired with the 'relative' observation builder and
+    its encode() method attached as observation_encoder -- the exact
+    contract A2C (and DQN) expect. max_steps is capped so a badly-behaved
+    untrained policy can't make a test hang on an episode that never
+    terminates.
+    """
+    agents = []
+    for i in range(1, n_pred + 1):
+        agents.append(Agent(agent_type="predator", agent_team=f"predator_{i}", agent_name=f"pred_{i}"))
+    for i in range(1, n_prey + 1):
+        agents.append(Agent(agent_type="prey", agent_team=f"prey_{i}", agent_name=f"prey_{i}"))
+
+    env = GridWorldEnv(
+        agents=agents, size=size, perc_num_obstacle=perc_obstacle,
+        render_mode=None, seed=seed, max_steps=max_steps,
+    )
+    observation_builder = RelativeObservation(
+        include_agents=True, include_obstacles=False, include_walls=False,
+        distance_type="manhattan",
+    )
+    env.observation_builder = observation_builder.build
+    env.observation_encoder = observation_builder.encode
+    return env
+
+
+def expected_state_dim(env):
+    """Computes the state_dim independently of A2C, straight from the
+    observation builder, so tests never hardcode a magic number that
+    would silently go stale if the encoder's padding scheme changes."""
+    obs, _ = env.reset()
+    first_agent = next(iter(obs))
+    encoded = env.observation_encoder(obs[first_agent], env)
+    return np.asarray(encoded, dtype=np.float32).reshape(-1).shape[0]
+
+
+def base_config(**overrides):
+    cfg = {
+        "hidden_layers": [8, 8],
+        "gamma": 0.99,
+        "n_steps": 4,
+        "entropy_coef": 0.01,
+        "value_loss_coef": 0.5,
+        "actor_learning_rate": 0.01,
+        "critic_learning_rate": 0.01,
+        "episodes": 3,
+        "seed": 0,
+        "grad_clip": 5.0,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+# ------------------------------------------------------------------
+# ActorNetwork -- tested in isolation from the env
+# ------------------------------------------------------------------
+
+class TestActorNetworkValidation:
+    def test_rejects_non_positive_input_dim(self):
+        with pytest.raises(ValueError):
+            ActorNetwork(input_dim=0, hidden_layers=[8], output_dim=5)
+
+    def test_rejects_non_positive_output_dim(self):
+        with pytest.raises(ValueError):
+            ActorNetwork(input_dim=2, hidden_layers=[8], output_dim=0)
+
+    def test_rejects_empty_hidden_layers(self):
+        with pytest.raises(ValueError):
+            ActorNetwork(input_dim=2, hidden_layers=[], output_dim=5)
+
+    def test_rejects_negative_hidden_layer_size(self):
+        with pytest.raises(ValueError):
+            ActorNetwork(input_dim=2, hidden_layers=[8, -4], output_dim=5)
+
+    def test_forward_output_shape(self):
+        net = ActorNetwork(input_dim=2, hidden_layers=[8, 8], output_dim=5)
+        out = net(torch.zeros((1, 2)))
+        assert out.shape == (1, 5)
+
+    def test_distribution_probs_sum_to_one(self):
+        net = ActorNetwork(input_dim=2, hidden_layers=[8], output_dim=5)
+        dist = net.distribution(torch.tensor([[0.1, -0.2]]))
+        total = dist.probs.sum(dim=1).item()
+        assert abs(total - 1.0) < 1e-5
+
+    def test_distribution_entropy_is_positive_at_init(self):
+        """A freshly initialized network shouldn't already be a degenerate
+        (zero-entropy) policy."""
+        net = ActorNetwork(input_dim=2, hidden_layers=[8], output_dim=5)
+        dist = net.distribution(torch.tensor([[0.0, 0.0]]))
+        assert dist.entropy().item() > 0.0
+
+    def test_sample_returns_valid_action_index(self):
+        net = ActorNetwork(input_dim=2, hidden_layers=[8], output_dim=5)
+        dist = net.distribution(torch.tensor([[0.3, -0.1]]))
+        action = dist.sample()
+        assert 0 <= int(action.item()) < 5
+
+
+# ------------------------------------------------------------------
+# CriticNetwork -- tested in isolation from the env
+# ------------------------------------------------------------------
+
+class TestCriticNetworkValidation:
+    def test_rejects_non_positive_input_dim(self):
+        with pytest.raises(ValueError):
+            CriticNetwork(input_dim=0, hidden_layers=[8])
+
+    def test_rejects_empty_hidden_layers(self):
+        with pytest.raises(ValueError):
+            CriticNetwork(input_dim=2, hidden_layers=[])
+
+    def test_forward_output_shape(self):
+        net = CriticNetwork(input_dim=2, hidden_layers=[8, 8])
+        out = net(torch.zeros((1, 2)))
+        assert out.shape == (1, 1)
+
+    def test_can_output_negative_values(self):
+        """Linear output layer -- V(s) must be free to go negative, this
+        env hands out large negative penalties."""
+        net = CriticNetwork(input_dim=1, hidden_layers=[4])
+        with torch.no_grad():
+            net.model[-1].bias.fill_(-5.0)
+            net.model[-1].weight.fill_(0.0)
+        out = net(torch.zeros((1, 1)))
+        assert out.item() < 0
+
+
+# ------------------------------------------------------------------
+# A2C initialization
+# ------------------------------------------------------------------
+
+class TestA2CInit:
+    def test_agent_ids_discovered(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        assert set(algo.agent_ids) == {"pred_1", "prey_1"}
+
+    def test_state_dim_matches_encoder_output(self):
+        env = make_env()
+        expected = expected_state_dim(env)
+        algo = A2C(env, base_config())
+        assert algo.state_dim == expected
+
+    def test_action_dim_matches_env_when_unset_in_config(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        assert algo.action_dim == 5  # discrete_5: right/up/left/down/noop
+
+    def test_actors_and_critics_created_per_agent(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        assert set(algo.actors.keys()) == {"pred_1", "prey_1"}
+        assert set(algo.critics.keys()) == {"pred_1", "prey_1"}
+
+    def test_optimizers_created_per_agent(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        assert set(algo.actor_optimizers.keys()) == {"pred_1", "prey_1"}
+        assert set(algo.critic_optimizers.keys()) == {"pred_1", "prey_1"}
+
+    def test_invalid_action_dim_raises(self):
+        env = make_env()
+        with pytest.raises(ValueError):
+            A2C(env, base_config(action_dim=4))  # env actually has 5 actions
+
+    def test_invalid_n_steps_raises(self):
+        env = make_env()
+        with pytest.raises(ValueError):
+            A2C(env, base_config(n_steps=0))
+
+    def test_missing_observation_encoder_raises(self):
+        env = make_env()
+        env.observation_encoder = None
+        with pytest.raises(ValueError):
+            A2C(env, base_config())
+
+
+# ------------------------------------------------------------------
+# Action selection
+# ------------------------------------------------------------------
+
+class TestA2CSelectActions:
+    def test_returns_action_for_every_agent(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        obs, _ = env.reset()
+        actions = algo.select_actions(obs)
+        assert set(actions.keys()) == {"pred_1", "prey_1"}
+
+    def test_actions_in_valid_range(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        obs, _ = env.reset()
+        actions = algo.select_actions(obs)
+        for a in actions.values():
+            assert 0 <= a < algo.action_dim
+
+    def test_greedy_eval_is_deterministic(self):
+        """With greedy_eval=True, repeated calls on the same observation
+        must return the same action every time (argmax, not sampling)."""
+        env = make_env()
+        algo = A2C(env, base_config(greedy_eval=True))
+        obs, _ = env.reset()
+        first = algo.select_actions(obs)
+        for _ in range(5):
+            again = algo.select_actions(obs)
+            assert again == first
+
+    def test_select_actions_does_not_build_gradient_graph(self):
+        """select_actions is the eval-facing method -- it must not leave
+        tensors requiring grad lying around (it's wrapped in no_grad)."""
+        env = make_env()
+        algo = A2C(env, base_config())
+        obs, _ = env.reset()
+        state = algo._encode_observation(obs["pred_1"])
+        state_t = torch.from_numpy(state).float().unsqueeze(0)
+        with torch.no_grad():
+            value = algo.critics["pred_1"](state_t)
+        assert not value.requires_grad
+
+
+# ------------------------------------------------------------------
+# Training
+# ------------------------------------------------------------------
+
+class TestA2CTrain:
+    def test_actor_weights_change_after_training(self):
+        env = make_env(max_steps=10)
+        algo = A2C(env, base_config(episodes=5, n_steps=3))
+        before = [p.clone() for p in algo.actors["pred_1"].parameters()]
+        algo.train()
+        after = list(algo.actors["pred_1"].parameters())
+        changed = any(not torch.equal(b, a) for b, a in zip(before, after))
+        assert changed
+
+    def test_critic_weights_change_after_training(self):
+        env = make_env(max_steps=10)
+        algo = A2C(env, base_config(episodes=5, n_steps=3))
+        before = [p.clone() for p in algo.critics["pred_1"].parameters()]
+        algo.train()
+        after = list(algo.critics["pred_1"].parameters())
+        changed = any(not torch.equal(b, a) for b, a in zip(before, after))
+        assert changed
+
+    def test_train_steps_counter_increases(self):
+        env = make_env(max_steps=10)
+        algo = A2C(env, base_config(episodes=3, n_steps=3))
+        assert algo._train_steps == 0
+        algo.train()
+        assert algo._train_steps > 0
+
+    def test_partial_final_rollout_still_updates(self):
+        """If an episode ends before n_steps transitions accumulate, the
+        partial rollout must still trigger an update (bootstrapping from 0
+        at the terminal state), not silently get dropped."""
+        env = make_env(max_steps=2)  # forces very short episodes
+        algo = A2C(env, base_config(episodes=2, n_steps=100))
+        algo.train()
+        assert algo._train_steps > 0
+
+    def test_curves_csv_written(self):
+        env = make_env(max_steps=10)
+        with tempfile.TemporaryDirectory() as tmp:
+            curves_path = os.path.join(tmp, "curves.csv")
+            algo = A2C(env, base_config(episodes=2, n_steps=3, curves_path=curves_path))
+            algo.train()
+            assert os.path.isfile(curves_path)
+            with open(curves_path) as fh:
+                lines = fh.readlines()
+            assert len(lines) == 3  # header + 2 episodes
+
+
+# ------------------------------------------------------------------
+# Persistence
+# ------------------------------------------------------------------
+
+class TestA2CPersistence:
+    def test_save_creates_file(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "a2c.pkl")
+            algo.save(path)
+            assert os.path.isfile(path)
+
+    def test_load_restores_actor_and_critic_weights(self):
+        env = make_env()
+        algo = A2C(env, base_config())
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "a2c.pkl")
+            algo.save(path)
+
+            loaded = A2C.load(env, base_config(), path)
+            for aid in algo.agent_ids:
+                for p_before, p_after in zip(
+                    algo.actors[aid].parameters(), loaded.actors[aid].parameters()
+                ):
+                    torch.testing.assert_close(p_before, p_after)
+                for p_before, p_after in zip(
+                    algo.critics[aid].parameters(), loaded.critics[aid].parameters()
+                ):
+                    torch.testing.assert_close(p_before, p_after)
+
+    def test_loaded_model_can_evaluate(self):
+        env = make_env(max_steps=10)
+        algo = A2C(env, base_config())
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "a2c.pkl")
+            algo.save(path)
+            loaded = A2C.load(env, base_config(greedy_eval=True), path)
+            loaded.evaluate(episodes=2, max_steps=10)  # should not raise


### PR DESCRIPTION

## Design summary:

- Added A2C Implementation with both actor and critic networks, test scripts and updated docs in `baselines/README.md`
- **Per-agent independent learners** (one actor + one critic per agent)
- **On-policy, no replay buffer.** A2C's gradient estimate is only valid for data collected under the *current* policy; reusing old transitions would bias it. Instead it collects a short `n_steps` rollout and updates immediately.
- **No target network.** DQN needs one because its Bellman target uses the network's own prediction, which would otherwise chase a moving goalpost. A2C's target (the n-step return) is built from actual observed rewards plus one bootstrap value, so it doesn't have that same runaway-feedback problem.
- **Separate actor/critic optimizers**, not a single combined loss. Keeps the two learning problems (policy improvement vs. value estimation) independently tunable and inspectable.
- Same `observation_encoder`  -- no changes to `core/`, `observations/`, or `registry/` were needed. Any existing or future observation builder works with A2C for free, as long as it implements `encode()`.
- Uses `env.action_space_plugin` for `action_dim`, including the same "fail fast if configured value doesn't match the env" validation.