### PR TITLE
Fix: Add deterministic (greedy) action selection for AC and A3C evaluation

### DIFF
--- a/src/baselines/A3C/a3c.py
+++ b/src/baselines/A3C/a3c.py
@@ -366,6 +366,10 @@ class A3C(BaseAlgorithm):
         self.return_norm_decay = float(config.get("return_norm_decay", 0.999))
         self.num_workers = int(config.get("num_workers", 4))
         self.verbose = bool(config.get("verbose", True))
+        # If True, select_actions() acts greedily (argmax over the policy's
+        # probabilities) instead of sampling. Exploration comes from sampling
+        # the stochastic policy. Evaluation scripts set this to True.
+        self.greedy_eval = bool(config.get("greedy_eval", False))
         self.log_interval = int(config.get("log_interval", 10))
         self.save_path = config.get("save_path", None)
         self.curves_path: Optional[str] = config.get("curves_path", None)
@@ -497,7 +501,11 @@ class A3C(BaseAlgorithm):
             with torch.no_grad():
                 logits, _ = self.networks[agent_id](state_t)
             dist = Categorical(logits=logits)
-            actions[agent_id] = int(dist.sample().item())
+            if self.greedy_eval:
+                action = torch.argmax(dist.probs, dim=1)
+            else:
+                action = dist.sample()
+            actions[agent_id] = int(action.item())
         return actions
 
     # ------------------------------------------------------------------

--- a/src/baselines/AC/actor_critic.py
+++ b/src/baselines/AC/actor_critic.py
@@ -74,6 +74,10 @@ class ActorCritic(BaseAlgorithm):
         self.return_norm_decay = float(config.get("return_norm_decay", 0.999))
         self.device = torch.device(config.get("device", "cpu"))
         self.verbose = bool(config.get("verbose", True))
+        # If True, select_actions() acts greedily (argmax over the policy's
+        # probabilities) instead of sampling. Exploration comes from sampling
+        # the stochastic policy. Evaluation scripts set this to True.
+        self.greedy_eval = bool(config.get("greedy_eval", False))
         self.log_interval = int(config.get("log_interval", 10))
         self.debug_first_episode = bool(config.get("debug_first_episode", True))
         self.save_path = config.get("save_path", None)
@@ -198,7 +202,11 @@ class ActorCritic(BaseAlgorithm):
             with torch.no_grad():
                 logits, _ = self.networks[agent_id](state_t)
             dist = Categorical(logits=logits)
-            actions[agent_id] = int(dist.sample().item())
+            if self.greedy_eval:
+                action = torch.argmax(dist.probs, dim=1)
+            else:
+                action = dist.sample()
+            actions[agent_id] = int(action.item())
         return actions
 
     # ------------------------------------------------------------------

--- a/src/multi_agent_package/scripts/run_a3c.py
+++ b/src/multi_agent_package/scripts/run_a3c.py
@@ -72,6 +72,7 @@ def main():
     else:
         if not args.load_path:
             raise SystemExit("--load-path is required for --mode eval")
+        algo_params["greedy_eval"] = True
         algo = A3C.load(env, algo_params, args.load_path)
         print(algo.evaluate())
 

--- a/src/multi_agent_package/scripts/run_a3c.py
+++ b/src/multi_agent_package/scripts/run_a3c.py
@@ -65,6 +65,11 @@ def main():
     )
     algo_params["env_fn"] = EnvFactory(configs)
 
+    if args.mode == "eval":
+        # A3C exploration comes from sampling the stochastic
+        # policy. For evaluation we want the greedy (argmax) action instead.
+        algo_params = dict(algo_params, greedy_eval=True)
+
     if args.mode == "train":
         algo = A3C(env, algo_params)
         algo.train()
@@ -72,7 +77,6 @@ def main():
     else:
         if not args.load_path:
             raise SystemExit("--load-path is required for --mode eval")
-        algo_params["greedy_eval"] = True
         algo = A3C.load(env, algo_params, args.load_path)
         print(algo.evaluate())
 

--- a/src/multi_agent_package/scripts/run_actor_critic.py
+++ b/src/multi_agent_package/scripts/run_actor_critic.py
@@ -49,6 +49,11 @@ def main():
     env = build_environment(configs)
     algo_params = configs["experiment"]["experiment"]["algorithm"].get("params", {})
 
+    if args.mode == "eval":
+        # AC exploration comes from sampling the stochastic
+        # policy. For evaluation we want the greedy (argmax) action instead.
+        algo_params = dict(algo_params, greedy_eval=True)
+
     if args.mode == "train":
         algo = ActorCritic(env, algo_params)
         algo.train()
@@ -56,7 +61,6 @@ def main():
     else:
         if not args.load_path:
             raise SystemExit("--load-path is required for --mode eval")
-        algo_params["greedy_eval"] = True
         algo = ActorCritic.load(env, algo_params, args.load_path)
         print(algo.evaluate())
 

--- a/src/multi_agent_package/scripts/run_actor_critic.py
+++ b/src/multi_agent_package/scripts/run_actor_critic.py
@@ -56,6 +56,7 @@ def main():
     else:
         if not args.load_path:
             raise SystemExit("--load-path is required for --mode eval")
+        algo_params["greedy_eval"] = True
         algo = ActorCritic.load(env, algo_params, args.load_path)
         print(algo.evaluate())
 

--- a/tests/test_baselines_a3c.py
+++ b/tests/test_baselines_a3c.py
@@ -14,9 +14,11 @@ import pytest
 import torch
 import torch.multiprocessing as mp
 
+
 from baselines.AC.network import ActorCriticNetwork
 from baselines.AC.return_normalizer import SharedReturnNormalizer
 from baselines.A3C.shared_adam import SharedAdam
+from baselines.A3C.a3c import A3C
 from baselines.A3C.a3c import _worker_loop
 
 
@@ -386,8 +388,6 @@ class TestA3CSelectActions:
     def test_greedy_eval_is_deterministic(self, dqn_env, a3c_config):
         """With greedy_eval=True, repeated calls on the same observation
         must return the same action every time (argmax, not sampling)."""
-        from baselines.A3C.a3c import A3C
-
         a3c_config["env_fn"] = lambda: dqn_env
         a3c_config["greedy_eval"] = True
         algo = A3C(dqn_env, a3c_config)

--- a/tests/test_baselines_a3c.py
+++ b/tests/test_baselines_a3c.py
@@ -383,6 +383,20 @@ class TestA3CSelectActions:
         for a in actions.values():
             assert 0 <= a < algo.action_dim
 
+    def test_greedy_eval_is_deterministic(self, dqn_env, a3c_config):
+        """With greedy_eval=True, repeated calls on the same observation
+        must return the same action every time (argmax, not sampling)."""
+        from baselines.A3C.a3c import A3C
+
+        a3c_config["env_fn"] = lambda: dqn_env
+        a3c_config["greedy_eval"] = True
+        algo = A3C(dqn_env, a3c_config)
+        obs, _ = dqn_env.reset()
+        first = algo.select_actions(obs)
+        for _ in range(5):
+            again = algo.select_actions(obs)
+            assert again == first
+
 
 class TestA3CTrain:
     def test_trains_end_to_end_with_real_worker_processes(self, a3c_config):

--- a/tests/test_baselines_actor_critic.py
+++ b/tests/test_baselines_actor_critic.py
@@ -6,6 +6,7 @@ one-step online ActorCritic algorithm (Sutton & Barto, Algorithm 13.5).
 import pytest
 import torch
 
+from baselines.AC.actor_critic import ActorCritic
 from baselines.AC.network import ActorCriticNetwork
 
 # ------------------------------------------------------------------
@@ -367,7 +368,6 @@ class TestActorCriticPersistence:
         (normalized-scale) output consistently -- resetting the normalizer
         to a fresh (0.0, eps) estimate would silently misinterpret an
         already-trained value head's predictions."""
-        from baselines.AC.actor_critic import ActorCritic
 
         ac_config["normalize_returns"] = True
         algo = ActorCritic(dqn_env, ac_config)

--- a/tests/test_baselines_actor_critic.py
+++ b/tests/test_baselines_actor_critic.py
@@ -135,7 +135,9 @@ class TestActorCriticInit:
         assert algo.normalize_returns is False
         assert algo.return_normalizers == {}
 
-    def test_normalize_returns_builds_one_normalizer_per_agent(self, dqn_env, ac_config):
+    def test_normalize_returns_builds_one_normalizer_per_agent(
+        self, dqn_env, ac_config
+    ):
         from baselines.AC.actor_critic import ActorCritic
 
         ac_config["normalize_returns"] = True
@@ -167,6 +169,19 @@ class TestActorCriticSelectActions:
         torch.manual_seed(123)
         second = algo_b.select_actions(obs)
         assert first == second
+
+    def test_greedy_eval_is_deterministic(self, dqn_env, ac_config):
+        """With greedy_eval=True, repeated calls on the same observation
+        must return the same action every time (argmax, not sampling)."""
+        from baselines.AC.actor_critic import ActorCritic
+
+        ac_config["greedy_eval"] = True
+        algo = ActorCritic(dqn_env, ac_config)
+        obs, _ = dqn_env.reset()
+        first = algo.select_actions(obs)
+        for _ in range(5):
+            again = algo.select_actions(obs)
+            assert again == first
 
 
 class TestActorCriticUpdate:
@@ -345,7 +360,9 @@ class TestActorCriticPersistence:
         second = loaded.select_actions(obs)
         assert first == second
 
-    def test_normalize_returns_state_survives_save_load(self, dqn_env, ac_config, tmp_path):
+    def test_normalize_returns_state_survives_save_load(
+        self, dqn_env, ac_config, tmp_path
+    ):
         """A loaded checkpoint must keep interpreting the value head's
         (normalized-scale) output consistently -- resetting the normalizer
         to a fresh (0.0, eps) estimate would silently misinterpret an
@@ -360,7 +377,10 @@ class TestActorCriticPersistence:
 
         loaded = ActorCritic.load(dqn_env, ac_config, str(path))
         for aid in algo.agent_ids:
-            assert loaded.return_normalizers[aid].stats() == algo.return_normalizers[aid].stats()
+            assert (
+                loaded.return_normalizers[aid].stats()
+                == algo.return_normalizers[aid].stats()
+            )
 
     def test_save_without_normalize_returns_has_no_normalizer_payload(
         self, dqn_env, ac_config, tmp_path


### PR DESCRIPTION
Closes issue #58 

## Problem

`ActorCritic.select_actions()` and `A3C.select_actions()` always call `Categorical(logits).sample()` — there is no greedy/deterministic mode. Unlike A2C, which already has a `greedy_eval` config flag, AC and A3C have no way to switch to argmax action selection during evaluation.

**Failure scenario:** Running `run_actor_critic.py --mode eval` or `run_a3c.py --mode eval` on a trained checkpoint still produces stochastic, non-reproducible action choices. This makes evaluation runs non-deterministic and impossible to compare fairly across seeds.

## Fix

Ports the same `greedy_eval` mechanism that A2C already has into both AC and A3C:

- **`greedy_eval` config flag** — defaults to `False` (preserving training-time exploration), but settable to `True` for deterministic evaluation.
- **`select_actions()` branching** — when `greedy_eval=True`, uses `torch.argmax(dist.probs, dim=1)` instead of `dist.sample()`.
- **Runner scripts** — `run_actor_critic.py` and `run_a3c.py` now automatically set `greedy_eval=True` when `--mode eval` is passed, using the same `dict(algo_params, greedy_eval=True)` pattern as `run_a2c.py` for consistency across all three baselines.

> **Note:** The `dist.sample()` call inside A3C's `_worker_loop` (training workers) is intentionally left unchanged — workers need stochastic exploration during training. Only the main-process `select_actions()` (called by `evaluate()`) is affected.

## Changes

| File | Change |
|------|--------|
| `src/baselines/AC/actor_critic.py` | Added `greedy_eval` config param in `__init__`; updated `select_actions()` with argmax branch |
| `src/baselines/A3C/a3c.py` | Added `greedy_eval` config param in `__init__`; updated `select_actions()` with argmax branch |
| `src/multi_agent_package/scripts/run_actor_critic.py` | Set `greedy_eval=True` before train/eval branch when `--mode eval` |
| `src/multi_agent_package/scripts/run_a3c.py` | Set `greedy_eval=True` before train/eval branch when `--mode eval` |

## Verification

- **Black** — all 4 files left unchanged (already formatted correctly).
- **Flake8** — zero violations.
- **Tests** — all 55 existing tests pass (`test_baselines_actor_critic.py` + `test_baselines_a3c.py`).
- No changes to training behavior (flag defaults to `False`).
